### PR TITLE
Overriding submit instead of click on partial forms

### DIFF
--- a/app/assets/javascripts/style_guide/partial.js
+++ b/app/assets/javascripts/style_guide/partial.js
@@ -7,13 +7,13 @@
     event.preventDefault();
   }
 
-  function preventDefaultOnClick(elements) {
+  function preventDefaultOn(elements, eventName) {
     for (var i = 0, element; element = elements[i]; i++) {
-      element.onclick = eventDefaultPreventer;
+      element.addEventListener(eventName, eventDefaultPreventer, false);
     }
   }
 
-  preventDefaultOnClick($forms);
-  preventDefaultOnClick($links);
-  preventDefaultOnClick($sources);
+  preventDefaultOn($forms, 'submit');
+  preventDefaultOn($sources, 'click');
+  preventDefaultOn($links, 'click');
 })();


### PR DESCRIPTION
Preventing default on the click event for forms won't stop the form from submitting; it's better to stop the submit event directly in case someone presses enter inside of the form.

Also, this allows form validations to fire, while stopping the form from submitting. I wanted to show form validations in our style guide, and this was necessary to do so.
