### PR TITLE
Adding the ability to configure the name of your applications main CSS f...

### DIFF
--- a/app/controllers/style_guide/application_controller.rb
+++ b/app/controllers/style_guide/application_controller.rb
@@ -1,7 +1,19 @@
 module StyleGuide
   class ApplicationController < ActionController::Base
+
+    protected
+
     def load_sections
       @sections = StyleGuide::Engine.config.style_guide.sections
+    end
+
+
+    #
+    # Set the @application_css instance variable based on our config
+    #
+    # @return [String] Current application_css value
+    def set_application_css
+      @application_css = Rails.application.config.style_guide.application_css
     end
   end
 end

--- a/app/controllers/style_guide/style_controller.rb
+++ b/app/controllers/style_guide/style_controller.rb
@@ -1,6 +1,7 @@
 module StyleGuide
   class StyleController < StyleGuide::ApplicationController
-    before_filter :load_sections
+
+    before_filter :load_sections, :set_application_css
 
     def index
       @current_section = @sections.first

--- a/app/views/layouts/style_guide/application.html.erb
+++ b/app/views/layouts/style_guide/application.html.erb
@@ -9,7 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
 
-    <%= stylesheet_link_tag    "application", :media => "all" %>
+    <%= stylesheet_link_tag    @application_css, :media => "all" %>
     <%= stylesheet_link_tag    "style_guide/application", :media => "all" %>
     <%= csrf_meta_tags %>
   </head>

--- a/lib/style_guide/config.rb
+++ b/lib/style_guide/config.rb
@@ -1,5 +1,10 @@
 module StyleGuide
   class Config
+
+    # !@attribute [w] application_css
+    #   @return [String] Path for main application css
+    attr_writer :application_css
+
     attr_reader :paths
 
     def self.bootstrap_glob
@@ -8,6 +13,16 @@ module StyleGuide
 
     def initialize(options = {})
       @paths = options[:paths] || [self.class.bootstrap_glob]
+    end
+
+    #
+    # Path to the main application.css
+    #
+    # Defaults to 'application.css'
+    #
+    # @return [String] Filename
+    def application_css
+      @application_css ||= "application.css"
     end
 
     def paths=(paths)

--- a/spec/controllers/style_guide/style_controller_spec.rb
+++ b/spec/controllers/style_guide/style_controller_spec.rb
@@ -22,6 +22,12 @@ describe StyleGuide::StyleController do
       assigns(:current_section).should == assigns(:sections).first
       assigns(:current_section).title.should == "Monkey Hammer"
     end
+
+    it 'assigns application_css' do
+      get(:index, use_route: :styles)
+      expect(assigns[:application_css]).to eql('application.css')
+    end
+
   end
 
   describe "#show" do
@@ -37,5 +43,11 @@ describe StyleGuide::StyleController do
       assigns(:current_section).should be_a StyleGuide::Section
       assigns(:current_section).title.should == "Monkey Hammer"
     end
+
+    it 'assigns application_css' do
+      get(:index, use_route: :styles)
+      expect(assigns[:application_css]).to eql('application.css')
+    end
+
   end
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -31,4 +31,10 @@ Dummy::Application.configure do
   config.middleware.insert_before(::Rack::Lock, ::Rack::LiveReload, :min_delay => 500)
 
   config.eager_load = false
+
+  #
+  # example configuration
+  #
+  # config.style_guide.application_css = 'special.css'
+
 end

--- a/spec/lib/style_guide/config_spec.rb
+++ b/spec/lib/style_guide/config_spec.rb
@@ -1,6 +1,20 @@
 require "spec_helper"
 
 describe StyleGuide::Config do
+
+  describe "#application_css" do
+
+    it 'defaults to application.css' do
+      expect(subject.application_css).to eql('application.css')
+    end
+
+    it 'can be set to a different value' do
+      subject.application_css = 'special.css'
+      expect(subject.application_css).to eql('special.css')
+    end
+
+  end
+
   describe "#paths" do
     context "when no paths have been added" do
       it { should have_at_least(1).path }


### PR DESCRIPTION
...ile

Not sure how useful this would be to most people, but I needed to slowly move my styles over to use Bootstrap/a new style guide and wanted an alternate application.css 

Also, it looks like most of the documentation is on the Wiki, so I didn't add anything on this option to the Readme.  Would be happy to add to the Wiki if that is the preferred method of documentation.

Added a configuration option to do so.  Usage:

``` ruby
# in config/environments/development.rb
config.style_guide.application_css = 'special.css'
```
