### PR TITLE
allows Application helper methods to be available in partials rendered from engine

### DIFF
--- a/lib/style_guide/partial.rb
+++ b/lib/style_guide/partial.rb
@@ -49,7 +49,7 @@ module StyleGuide
     private
 
     def action_view
-      ActionView::Base.new(Rails.root.join("app", "views"))
+      ApplicationController.new.view_context
     end
 
     def style_guide_scope


### PR DESCRIPTION
I wanted to use helper methods for [Font-Awesome-Rails](https://github.com/bokmann/font-awesome-rails) in my style guide partials.  However they weren't available to the partial for some reason.  I ended up tracking it down to this instantiation of a new view context as opposed to using the ApplicationController's view context.
